### PR TITLE
Fix(update): Handle empty release response

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -27,9 +27,10 @@ func checkForUpdate() (hasUpdate bool, updateMessage string, err error) {
 		return false, "", nil
 	}
 
-	// get release info
+	// get release info (nil when not available)
 	releaseInfo, err := utils.GetLatestReleaseFromGitHub(config.AppConfig.PrivadoRepositoryName)
-	if err != nil || releaseInfo.TagName == "" || releaseInfo.PublishedAt == "" {
+
+	if err != nil || releaseInfo == nil || releaseInfo.TagName == "" || releaseInfo.PublishedAt == "" {
 		return false, "", err
 	}
 


### PR DESCRIPTION
This will fix #7 and unblock the team for testing. The cause was 404/nil response from GitHub API due to the repository being private.

Further, I've noticed a different behavior in the update flow from [privado](https://github.com/Privado-Inc/privado), which is something I will continue to investigate and create a separate PR if required. 
