### PR TITLE
fix: add os-specific implementation for write perm

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -100,7 +100,7 @@ func update(cmd *cobra.Command, args []string) {
 	}
 
 	// check for appropriate permissions
-	hasPerm, err := fileutils.HasWritePermissionToFileNew(currentExecPath)
+	hasPerm, err := fileutils.HasWritePermissionToFile(currentExecPath)
 	if err != nil {
 		exitUpdate(fmt.Sprintf("Could not open executable for write: %s", err), true)
 	}

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -28,11 +28,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/codeclysm/extract/v3"
 )
@@ -104,33 +102,6 @@ func GetPathToCurrentBinary() (string, error) {
 	}
 
 	return resolvedFilePath, nil
-}
-
-// yields error on linux systems after upgrades
-// Could not open executable for write: open privado-cli/privado: text file busy
-func HasWritePermissionToFile(filePath string) (bool, error) {
-	file, err := os.OpenFile(filePath, os.O_RDWR, 0744)
-	if err != nil {
-		if errors.Is(err, fs.ErrPermission) {
-			return false, nil
-		}
-		return false, err
-	}
-	defer file.Close()
-
-	return true, nil
-}
-
-func HasWritePermissionToFileNew(filePath string) (bool, error) {
-	err := syscall.Access(filePath, uint32(os.O_RDWR))
-	if err != nil {
-		if errors.Is(err, fs.ErrPermission) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }
 
 func ExtractTarGzFile(sourceFile, target string) error {

--- a/pkg/fileutils/fileutils_darwin.go
+++ b/pkg/fileutils/fileutils_darwin.go
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package fileutils
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// syscall for unix-based instead of open
+func HasWritePermissionToFile(filePath string) (bool, error) {
+	err := syscall.Access(filePath, uint32(os.O_RDWR))
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/fileutils/fileutils_linux.go
+++ b/pkg/fileutils/fileutils_linux.go
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package fileutils
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// syscall for unix-based instead of open
+func HasWritePermissionToFile(filePath string) (bool, error) {
+	err := syscall.Access(filePath, uint32(os.O_RDWR))
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/fileutils/fileutils_windows.go
+++ b/pkg/fileutils/fileutils_windows.go
@@ -1,0 +1,46 @@
+/**
+ * This file is part of Privado OSS.
+ *
+ * Privado is an open source static code analysis tool to discover data flows in the code.
+ * Copyright (C) 2022 Privado, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, contact support@privado.ai
+ *
+ */
+
+package fileutils
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+// yields error on unix-based systems after upgrades
+// Could not open executable for write: open privado-cli/privado: text file busy
+// using same for windows & moving to syscall for unix
+func HasWritePermissionToFile(filePath string) (bool, error) {
+	file, err := os.OpenFile(filePath, os.O_RDWR, 0744)
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer file.Close()
+
+	return true, nil
+}


### PR DESCRIPTION
Fixes the incompatibility issue for windows. The change uses the previous implementation for windows while migrating for unix-based ones.
