### PR TITLE
hotfix: change scope for err for func OpenURLInBrowser

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -356,7 +356,8 @@ func RunImage(opts ...RunImageOption) error {
 				url := utils.ExtractURLFromString(message)
 				if url != "" {
 					telemetry.DefaultInstance.RecordAtomicMetric("didParseCloudLink", true)
-					if err := utils.OpenURLInBrowser(url); err != nil {
+					err := utils.OpenURLInBrowser(url)
+					if err != nil {
 						telemetry.DefaultInstance.RecordArrayMetric("error", err)
 					}
 					telemetry.DefaultInstance.RecordAtomicMetric("didAutoSpawnBrowser", err == nil)


### PR DESCRIPTION
**Problem:** Incorrect metric value for `didAutoSpawnBrowser` 

This was due to the usage of `err` from the parent scope. Fixed by removing `err` declaration within `if`