### PR TITLE
Add flag for test output 

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -71,6 +71,7 @@ func defineScanFlags(cmd *cobra.Command) {
 	scanCmd.Flags().Bool("disable-flow-separation-by-data-element", false, "Experimental: If specified, filtering of flow using 'flow separation by data element algorithm' will be avoided")
 	scanCmd.Flags().Bool("disable-2nd-level-closure", false, "Experimental: If specified, 2nd level source derivation will be turned on")
 	scanCmd.Flags().Bool("generate-unresolved-name-report", false, "Flag to enable generation unresolved method name reports")
+	scanCmd.Flags().Bool("test-output", false, "Flag to generate unfiltered flow output getting direclty from joern")
 }
 
 func scan(cmd *cobra.Command, args []string) {
@@ -89,6 +90,7 @@ func scan(cmd *cobra.Command, args []string) {
 	disableFlowSeperationByDataElement, _ := cmd.Flags().GetBool("disable-flow-separation-by-data-element")
 	disable2ndLevelClosure, _ := cmd.Flags().GetBool("disable-2nd-level-closure")
 	generateUnresolvedNameReport, _ := cmd.Flags().GetBool("generate-unresolved-name-report")
+	testOutput, _ := cmd.Flags().GetBool("test-output")
 
 	externalRules, _ := cmd.Flags().GetString("config")
 	if externalRules != "" {
@@ -181,6 +183,10 @@ func scan(cmd *cobra.Command, args []string) {
 
 	if generateUnresolvedNameReport {
 		commandArgs = append(commandArgs, "-ur")
+	}
+
+	if testOutput {
+		commandArgs = append(commandArgs, "-tout")
 	}
 
 	// run image with options

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -71,7 +71,7 @@ func defineScanFlags(cmd *cobra.Command) {
 	scanCmd.Flags().Bool("disable-flow-separation-by-data-element", false, "Experimental: If specified, filtering of flow using 'flow separation by data element algorithm' will be avoided")
 	scanCmd.Flags().Bool("disable-2nd-level-closure", false, "Experimental: If specified, 2nd level source derivation will be turned on")
 	scanCmd.Flags().Bool("generate-unresolved-name-report", false, "Flag to enable generation unresolved method name reports")
-	scanCmd.Flags().Bool("test-output", false, "Flag to generate unfiltered flow output getting direclty from joern")
+	scanCmd.Flags().Bool("generate-unfiltered-report", false, "If specified, additionally generates an unfiltered flow report")
 }
 
 func scan(cmd *cobra.Command, args []string) {
@@ -90,7 +90,7 @@ func scan(cmd *cobra.Command, args []string) {
 	disableFlowSeperationByDataElement, _ := cmd.Flags().GetBool("disable-flow-separation-by-data-element")
 	disable2ndLevelClosure, _ := cmd.Flags().GetBool("disable-2nd-level-closure")
 	generateUnresolvedNameReport, _ := cmd.Flags().GetBool("generate-unresolved-name-report")
-	testOutput, _ := cmd.Flags().GetBool("test-output")
+	generateUnfilteredReport, _ := cmd.Flags().GetBool("generate-unfiltered-report")
 
 	externalRules, _ := cmd.Flags().GetString("config")
 	if externalRules != "" {
@@ -185,7 +185,7 @@ func scan(cmd *cobra.Command, args []string) {
 		commandArgs = append(commandArgs, "-ur")
 	}
 
-	if testOutput {
+	if generateUnfilteredReport {
 		commandArgs = append(commandArgs, "-tout")
 	}
 


### PR DESCRIPTION
Add flag to export a separate json file which contain only unfiltered flow when --test-output or -tout flag provided.
JIRA Ticket: https://privado-ai.atlassian.net/browse/LE-82 