### PR TITLE
fix go.mod to be v2 matching the current major release/tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Privado-Inc/privado-cli
+module github.com/Privado-Inc/privado-cli/v2
 
 go 1.17
 


### PR DESCRIPTION
Follows go conventions, plus this allow it to be included in go.mod files, e.g.
`require github.com/Privado-Inc/privado-cli/v2 v2.2.9`

Whereas this isn't currently possible due to error
`github.com/Privado-Inc/privado-cli/v2@v2.2.9: go.mod has non-.../v2 module path "github.com/Privado-Inc/privado-cli" (and .../v2/go.mod does not exist) at revision v2.2.9`

As the module in the `privado-cli`'s `go.mod` file is yet to specify it is v2